### PR TITLE
Fix start time extraction

### DIFF
--- a/Tools/getFileAndEQseconds.m
+++ b/Tools/getFileAndEQseconds.m
@@ -11,6 +11,16 @@ function [FIsec, FIyyyy, EQsec, Omarker] = getFileAndEQseconds(F,eqin,offset)
 % Windows user can try a renamer , for example 1-4aren (one-for all renamer)
 % http://www.1-4a.com/rename/ perhaps this adress is still valid
 
+%==========================================================================
+% Yvonne Fröhlich (YF), Karlsruhe Institute of Technology (KIT),
+% Email: yvonne.froehlich@kit.edu
+% July-December 2021
+%
+% modifications to fix extraction of start time by SplitLab
+% (unconsidered milliseconds or seconds of start time)
+%
+%==========================================================================
+
 global config
 
 
@@ -22,22 +32,37 @@ if config.UseHeaderTimes | strcmp(config.FileNameConvention, '*.e; *.n; *.z')
         catch
             sac = sl_rsacsun([config.datadir filesep F(k,:)]);
         end
-        [FIyyyy(k), FIddd(k), FIHH(k), FIMM(k), FISS(k)] =...
-            sl_lh(sac, 'NZYEAR','NZJDAY','NZHOUR','NZMIN', 'NZSEC'); 
+%        [FIyyyy(k), FIddd(k), FIHH(k), FIMM(k), FISS(k)] =...
+%            sl_lh(sac, 'NZYEAR','NZJDAY','NZHOUR','NZMIN', 'NZSEC');
+        [FIyyyy(k), FIddd(k), FIHH(k), FIMM(k), FISS(k), FImmm(k)] =...
+            sl_lh(sac, 'NZYEAR','NZJDAY','NZHOUR','NZMIN', 'NZSEC', 'NZMSEC'); % YF add msec 2021/06/24
         Omarker(k) = sl_lh(sac, 'O');
     end
     
      Omarker(Omarker == -12345) = 0;  %verify, if O-marker is set   
-     FIsec  =  FISS + FIMM*60 + FIHH*3600 + (FIddd)*86400 + Omarker;
+%     FIsec  =  FISS + FIMM*60 + FIHH*3600 + (FIddd)*86400 + Omarker;
+     FIsec  =  FImmm/1000 + FISS + FIMM*60 + FIHH*3600 + (FIddd)*86400 + Omarker; % YF add msec 2021/06/24
 
     fclose all;
 
 
 
 else % USE FILENAME
+
+	% YF add warning 2021/Nov/28
+    msgbox( {'When extracting the \bfstart time\rm from the \bffile name\rm be sure that this time is \bf\itreally\rm the exact \bfstart time\rm of the \bftrace!'}, ...
+            'Check start time' ,'warn', ...
+            struct('WindowStyle',{'modal'},'Interpreter',{'tex'}) );
+
     switch config.FileNameConvention
         case 'mseed2sac1'
             % mseed2sac format: QT.ANIL.00.HHZ.D.2012,321,18:00:00.SAC
+
+			% YF add warning 2021/Nov/28
+			msgbox( 'Only correct for traces with start times of \bfzero milliseconds\rm!', ...
+                    'Check milliseconds' ,'warn', ...
+                    struct('WindowStyle',{'modal'},'Interpreter',{'tex'}) );
+
             FIsec = zeros(1,length(F(:,1)));
             FIyyyy = zeros(1,length(F(:,1)));
             
@@ -72,6 +97,12 @@ else % USE FILENAME
         case 'mseed2sac2'
             % seems mseed2sac changed naming convention...
             % mseed2sac format: IU.HRV.00.BH1.M.2011.246.044859.SAC
+
+			% YF add warning 2021/Nov/28
+			msgbox( 'Only correct for traces with start times of \bfzero milliseconds\rm!', ...
+                    'Check milliseconds' ,'warn', ...
+                    struct('WindowStyle',{'modal'},'Interpreter',{'tex'}) );
+
             FIsec = zeros(1,length(F(:,1)));
             FIyyyy = zeros(1,length(F(:,1)));
             
@@ -118,6 +149,12 @@ else % USE FILENAME
 
         case 'SEISAN'
             % SEISAN format '2003-05-26-0947-20S.HOR___003_HORN__BHZ__SAC'
+
+			% YF add warning 2021/Nov/28
+			msgbox( 'Only correct for traces with start times of \bfzero milliseconds\rm!', ...
+                    'Check milliseconds' ,'warn', ...
+                    struct('WindowStyle',{'modal'},'Interpreter',{'tex'}) );
+
             FIyyyy = str2num(F(:,1:4));
             FImonth= str2num(F(:,6:7));
             FIdd   = str2num(F(:,9:10));
@@ -131,6 +168,12 @@ else % USE FILENAME
 
         case 'YYYY.JJJ.hh.mm.ss.stn.sac.e'
             %  Format: 1999.136.15.25.00.ATD.sac.z
+
+			% YF add warning 2021/Nov/28
+			msgbox( 'Only correct for traces with start times of \bfzero milliseconds\rm!', ...
+                    'Check milliseconds' ,'warn', ...
+                    struct('WindowStyle',{'modal'},'Interpreter',{'tex'}) );
+
             FIyyyy = str2num(F(:,1:4));
             FIddd  = str2num(F(:,6:8));
             FIHH   = str2num(F(:,10:11));
@@ -140,6 +183,12 @@ else % USE FILENAME
 
         case 'YYYY.MM.DD-hh.mm.ss.stn.sac.e';
             % Format: 2003.10.07-05.07.15.DALA.sac.z
+
+			% YF add warning 2021/Nov/28
+			msgbox( 'Only correct for traces with start times of \bfzero milliseconds\rm!', ...
+                    'Check milliseconds' ,'warn', ...
+                    struct('WindowStyle',{'modal'},'Interpreter',{'tex'}) );
+
             FIyyyy = str2num(F(:,1:4));
             FImonth= str2num(F(:,6:7));
             FIdd   = str2num(F(:,9:10));
@@ -152,6 +201,12 @@ else % USE FILENAME
             
         case 'YYYY_MM_DD_hhmm_stnn.sac.e';
             % Format: 2005_03_02_1155_pptl.sac (LDG/CEA data)
+
+			% YF add warning 2021/Nov/28
+			msgbox( 'Only correct for traces with start times of \bfzero seconds\rm!', ...
+                    'Check seconds' ,'warn', ...
+                    struct('WindowStyle',{'modal'},'Interpreter',{'tex'}) );
+
             FIyyyy = str2num(F(:,1:4));
             FImonth= str2num(F(:,6:7));
             FIdd   = str2num(F(:,9:10));
@@ -163,6 +218,13 @@ else % USE FILENAME
 
         case 'stn.YYMMDD.hhmmss.e'
             % Format: fp2.030723.213056.X (BroadBand OBS data)
+
+			% YF add warning 2021/Nov/28
+			msgbox( {'Only correct for traces with start times of \bfzero milliseconds\rm!'; ...
+					'Only correct for \bfyear 2000 or later\rm!'}, ...
+                    'Check milliseconds and year' ,'warn', ...
+                    struct('WindowStyle',{'modal'},'Interpreter',{'tex'}) );
+
             FIyyyy = 2000 + str2num(F(:,5:6));%only two-digit year identifier => add 2000, assuming no OBS data before 2000
             FImonth= str2num(F(:,7:8));
             FIdd   = str2num(F(:,9:10));

--- a/Tools/getFileAndEQseconds.m
+++ b/Tools/getFileAndEQseconds.m
@@ -12,11 +12,12 @@ function [FIsec, FIyyyy, EQsec, Omarker] = getFileAndEQseconds(F,eqin,offset)
 % http://www.1-4a.com/rename/ perhaps this adress is still valid
 
 %==========================================================================
-% Yvonne Fröhlich (YF), Karlsruhe Institute of Technology (KIT),
-% Email: yvonne.froehlich@kit.edu
 % July-December 2021
-%
-% modifications to fix extraction of start time by SplitLab
+% Yvonne Fröhlich (YF), Karlsruhe Institute of Technology (KIT),
+% ORCID: 0000-0002-8566-0619
+% Email: yvonne.froehlich@kit.edu
+% GitHub: https://github.com/yvonnefroehlich/SplitLab-TemporalAlignment
+% => modifications to fix extraction of start time by SplitLab
 % (unconsidered milliseconds or seconds of start time)
 %
 %==========================================================================

--- a/Tools/getFileAndEQseconds.m
+++ b/Tools/getFileAndEQseconds.m
@@ -19,7 +19,7 @@ function [FIsec, FIyyyy, EQsec, Omarker] = getFileAndEQseconds(F,eqin,offset)
 % GitHub: https://github.com/yvonnefroehlich/SplitLab-TemporalAlignment
 % => modifications to fix extraction of start time by SplitLab
 % (unconsidered milliseconds or seconds of start time)
-% publication: Fröhlich, Grund, Ritter (2022) Annals of Geophysics
+% Publication: Fröhlich, Grund, Ritter (2022) Annals of Geophysics
 % https://doi.org/10.4401/ag-8781
 %
 %==========================================================================

--- a/Tools/getFileAndEQseconds.m
+++ b/Tools/getFileAndEQseconds.m
@@ -19,6 +19,8 @@ function [FIsec, FIyyyy, EQsec, Omarker] = getFileAndEQseconds(F,eqin,offset)
 % GitHub: https://github.com/yvonnefroehlich/SplitLab-TemporalAlignment
 % => modifications to fix extraction of start time by SplitLab
 % (unconsidered milliseconds or seconds of start time)
+% publication: Fröhlich, Grund, Ritter (2022) Annals of Geophysics
+% https://doi.org/10.4401/ag-8781
 %
 %==========================================================================
 


### PR DESCRIPTION
This PR addresses an error in the start time extraction by the SplitLab function ``~\SplitLab\Tools\getFileAndEQseconds.m``.

In some cases, the milliseconds or seconds in the start times of the single traces (Z, N, E components) are not considered. The resulting wrong temporal alignment of the single traces *relative* to each other causes a wrong horizontal particle motion and wrong waveforms in the ray (LQT) coordinate system leading to wrong shear wave splitting measurements.
See also: https://github.com/yvonnefroehlich/SplitLab-TemporalAlignment.

Changes of the function ``getFileAndEQseconds.m`` (for this SplitLab version 1.3.0):
- option ``extract start time from SAC-header``: consideration of the milliseconds
- option ``extract start time from filename``: warnings regarding this issue